### PR TITLE
fix: parse object and array params from JSON strings

### DIFF
--- a/src/executor/commander-builder.test.ts
+++ b/src/executor/commander-builder.test.ts
@@ -1,9 +1,10 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import { Command } from "commander";
 import { loadSpec } from "../parser/loader.js";
 import { extractOperations } from "../parser/extractor.js";
 import { buildCommands } from "./commander-builder.js";
 import type { RuntimeConfig } from "./types.js";
+import type { Operation } from "../parser/types.js";
 import path from "node:path";
 
 const FIXTURE = path.resolve("test/fixtures/petstore.yaml");
@@ -15,6 +16,8 @@ const config: RuntimeConfig = {
   output: "json",
   verbose: false,
   quiet: false,
+  dryRun: false,
+  validate: false,
 };
 
 describe("buildCommands", () => {
@@ -101,5 +104,123 @@ describe("buildCommands", () => {
     const petsCmd = program.commands.find((c) => c.name() === "pets")!;
     const listCmd = petsCmd.commands.find((c) => c.name() === "list")!;
     expect(listCmd.description()).toBe("List all pets");
+  });
+});
+
+describe("collectParams JSON parsing", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("parses object params from JSON strings", async () => {
+    const op: Operation = {
+      id: "createVideos",
+      method: "POST",
+      path: "/videos",
+      summary: "Create video",
+      description: "",
+      params: [
+        { name: "name", in: "body", type: "string", required: true, description: "" },
+        { name: "content", in: "body", type: "object", required: true, description: "" },
+      ],
+      bodyRequired: true,
+      security: [],
+    };
+
+    let capturedBody: unknown;
+    vi.stubGlobal("fetch", vi.fn().mockImplementation((_url: string, init: RequestInit) => {
+      capturedBody = JSON.parse(init.body as string);
+      return Promise.resolve({
+        status: 200,
+        statusText: "OK",
+        headers: new Map([["content-type", "application/json"]]),
+        text: () => Promise.resolve("{}"),
+      });
+    }));
+
+    const spec = await loadSpec(FIXTURE);
+    const program = new Command();
+    program.exitOverride();
+    buildCommands(program, [{ tag: "Videos", description: "", operations: [op] }], config, spec);
+
+    await program.parseAsync(["node", "test", "Videos", "create", "--name", "Test", "--content", '{"text":"hello"}']);
+
+    expect(capturedBody).toEqual({ name: "Test", content: { text: "hello" } });
+
+    vi.unstubAllGlobals();
+  });
+
+  it("parses array params from JSON strings", async () => {
+    const op: Operation = {
+      id: "createItem",
+      method: "POST",
+      path: "/items",
+      summary: "Create items",
+      description: "",
+      params: [
+        { name: "tags", in: "body", type: "array", required: true, description: "" },
+      ],
+      bodyRequired: true,
+      security: [],
+    };
+
+    let capturedBody: unknown;
+    vi.stubGlobal("fetch", vi.fn().mockImplementation((_url: string, init: RequestInit) => {
+      capturedBody = JSON.parse(init.body as string);
+      return Promise.resolve({
+        status: 200,
+        statusText: "OK",
+        headers: new Map([["content-type", "application/json"]]),
+        text: () => Promise.resolve("{}"),
+      });
+    }));
+
+    const spec = await loadSpec(FIXTURE);
+    const program = new Command();
+    program.exitOverride();
+    buildCommands(program, [{ tag: "Items", description: "", operations: [op] }], config, spec);
+
+    await program.parseAsync(["node", "test", "Items", "create", "--tags", '["a","b"]']);
+
+    expect(capturedBody).toEqual({ tags: ["a", "b"] });
+
+    vi.unstubAllGlobals();
+  });
+
+  it("falls back to string when JSON parse fails", async () => {
+    const op: Operation = {
+      id: "createThings",
+      method: "POST",
+      path: "/things",
+      summary: "Create thing",
+      description: "",
+      params: [
+        { name: "data", in: "body", type: "object", required: true, description: "" },
+      ],
+      bodyRequired: true,
+      security: [],
+    };
+
+    let capturedBody: unknown;
+    vi.stubGlobal("fetch", vi.fn().mockImplementation((_url: string, init: RequestInit) => {
+      capturedBody = JSON.parse(init.body as string);
+      return Promise.resolve({
+        status: 200,
+        statusText: "OK",
+        headers: new Map([["content-type", "application/json"]]),
+        text: () => Promise.resolve("{}"),
+      });
+    }));
+
+    const spec = await loadSpec(FIXTURE);
+    const program = new Command();
+    program.exitOverride();
+    buildCommands(program, [{ tag: "Things", description: "", operations: [op] }], config, spec);
+
+    await program.parseAsync(["node", "test", "Things", "create", "--data", "not-json"]);
+
+    expect(capturedBody).toEqual({ data: "not-json" });
+
+    vi.unstubAllGlobals();
   });
 });

--- a/src/executor/commander-builder.ts
+++ b/src/executor/commander-builder.ts
@@ -95,6 +95,18 @@ function collectParams(
       case "boolean":
         params[p.name] = value === true || value === "true";
         break;
+      case "object":
+      case "array":
+        if (typeof value === "string") {
+          try {
+            params[p.name] = JSON.parse(value);
+          } catch {
+            params[p.name] = value;
+          }
+        } else {
+          params[p.name] = value;
+        }
+        break;
       default:
         params[p.name] = value;
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -148,6 +148,12 @@ function buildDynamicCommands(
             params[p.name] = Number(opts[p.name]);
           } else if (p.type === "boolean") {
             params[p.name] = opts[p.name] === true || opts[p.name] === "true";
+          } else if ((p.type === "object" || p.type === "array") && typeof opts[p.name] === "string") {
+            try {
+              params[p.name] = JSON.parse(opts[p.name] as string);
+            } catch {
+              params[p.name] = opts[p.name];
+            }
           } else {
             params[p.name] = opts[p.name];
           }


### PR DESCRIPTION
## Summary
- JSON strings passed via CLI flags for `object`/`array` type params are now parsed into proper objects before sending to the API
- Fixed in both `index.ts` (main flow) and `commander-builder.ts` (alternate flow)
- Falls back gracefully to raw string if JSON parsing fails

## Changes
- `src/index.ts` — Added `object`/`array` case to param type coercion in action handler
- `src/executor/commander-builder.ts` — Added same `object`/`array` case to `collectParams()` switch
- `src/executor/commander-builder.test.ts` — 3 new tests: object parsing, array parsing, invalid JSON fallback

## Test plan
- [x] All 85 tests pass (82 existing + 3 new)
- [x] Build passes clean
- [ ] Manual: `--content '{"text":"hello"}'` sends parsed object, not string
- [ ] Manual: `--tags '["a","b"]'` sends parsed array
- [ ] Manual: `--data "not-json"` falls back to string without error

Closes #15

---
🤖 Implemented by Claude Code dev-pipeline