### PR TITLE
feat: HTTP Basic auth support via --basic flag

### DIFF
--- a/src/auth/auth.test.ts
+++ b/src/auth/auth.test.ts
@@ -115,6 +115,25 @@ describe("resolveAuth", () => {
     const auth = await resolveAuth({ rcAuthToken: "$SECRET_TOK" }, minimalSpec, { SECRET_TOK: "resolved-secret" });
     expect(auth.value).toBe("resolved-secret");
   });
+
+  it("--basic sets basic auth with user:password value", async () => {
+    const auth = await resolveAuth({ basic: "user:pass" }, minimalSpec, {});
+    expect(auth.type).toBe("basic");
+    expect(auth.value).toBe("user:pass");
+  });
+
+  it("--basic resolves env variable", async () => {
+    const auth = await resolveAuth({ basic: "$DATAFORSEO_AUTH" }, minimalSpec, { DATAFORSEO_AUTH: "login:secret" });
+    expect(auth.type).toBe("basic");
+    expect(auth.value).toBe("login:secret");
+  });
+
+  it("--basic takes priority over saved profile", async () => {
+    await saveProfile("default", { type: "bearer", value: "profile-tok" });
+    const auth = await resolveAuth({ basic: "u:p" }, minimalSpec, {});
+    expect(auth.type).toBe("basic");
+    expect(auth.value).toBe("u:p");
+  });
 });
 
 describe("auth config (profile persistence)", () => {

--- a/src/auth/flags.ts
+++ b/src/auth/flags.ts
@@ -5,6 +5,7 @@ import { getProfile } from "./config.js";
 export interface AuthFlags {
   token?: string;
   apiKey?: string;
+  basic?: string;
   authHeader?: string;
   headers?: Record<string, string>;
   profile?: string;
@@ -32,6 +33,13 @@ export async function resolveAuth(
   if (flags.apiKey) {
     const headerName = detectApiKeyHeader(spec) ?? "X-API-Key";
     return { type: "apiKey", value: resolveEnvVar(flags.apiKey, env, "--api-key"), headerName };
+  }
+  if (flags.basic) {
+    const value = resolveEnvVar(flags.basic, env, "--basic");
+    if (!value.includes(":")) {
+      console.error(`Warning: --basic expects "user:password" format, got value without colon.`);
+    }
+    return { type: "basic", value };
   }
   if (flags.authHeader) {
     return { type: "bearer", value: resolveEnvVar(flags.authHeader, env, "--auth-header") };

--- a/src/cli/agent-help.ts
+++ b/src/cli/agent-help.ts
@@ -76,6 +76,7 @@ export function resolveAuthHint(spec: OpenAPISpec): string {
 
   for (const scheme of Object.values(schemes)) {
     if (scheme.type === "http" && scheme.scheme === "bearer") return "bearer --token <TOKEN>";
+    if (scheme.type === "http" && scheme.scheme === "basic") return "basic --basic <USER:PASSWORD>";
     if (scheme.type === "apiKey") return `apiKey --api-key <KEY> (header: ${scheme.name})`;
   }
 

--- a/src/cli/dry-run.ts
+++ b/src/cli/dry-run.ts
@@ -25,6 +25,8 @@ export function printDryRun(op: Operation, params: Record<string, unknown>, conf
     headers.push(`Authorization: Bearer ${config.auth.value}`);
   } else if (config.auth.type === "apiKey") {
     headers.push(`${config.auth.headerName ?? "X-API-Key"}: ${config.auth.value}`);
+  } else if (config.auth.type === "basic") {
+    headers.push(`Authorization: Basic ${Buffer.from(config.auth.value).toString("base64")}`);
   } else if (config.auth.type === "headers" && config.auth.headers) {
     for (const [k, v] of Object.entries(config.auth.headers)) {
       headers.push(`${k}: ${v}`);

--- a/src/cli/flags.ts
+++ b/src/cli/flags.ts
@@ -16,7 +16,7 @@ export function getFlagValues(args: string[], flag: string): string[] {
 }
 
 export function filterTocliFlags(argv: string[]): string[] {
-  const valueFlags = new Set(["--spec", "--output", "--max-items", "--token", "--api-key", "--base-url", "--profile", "--env", "--header", "-H"]);
+  const valueFlags = new Set(["--spec", "--output", "--max-items", "--token", "--api-key", "--basic", "--base-url", "--profile", "--env", "--header", "-H"]);
   const boolFlags = new Set(["--verbose", "--quiet", "--dry-run", "--validate", "--agent-help", "--filter-pii"]);
   const result: string[] = [];
   let i = 0;

--- a/src/index.ts
+++ b/src/index.ts
@@ -90,6 +90,7 @@ async function main() {
       {
         token: getFlagValue(rawArgs, "--token"),
         apiKey: getFlagValue(rawArgs, "--api-key"),
+        basic: getFlagValue(rawArgs, "--basic"),
         headers: parseHeaderArgs(rawArgs),
         profile: getFlagValue(rawArgs, "--profile"),
         rcAuthType,

--- a/src/templates/commands.ts
+++ b/src/templates/commands.ts
@@ -68,6 +68,8 @@ async function handleUse(args: string[]): Promise<void> {
     tocliArgs.push("--token", token);
   } else if (token && template.authType === "apiKey") {
     tocliArgs.push("--api-key", token);
+  } else if (token && template.authType === "basic") {
+    tocliArgs.push("--basic", token);
   }
 
   const remaining = args.slice(1);
@@ -166,7 +168,7 @@ async function handleAdd(args: string[]): Promise<void> {
     categories: ["custom"],
     specUrl: specValue,
     baseUrl: baseUrl ?? (isUrl ? specSource.replace(/\/openapi\.(json|yaml)$/, "") : "http://localhost:3000"),
-    authType: (getFlagValue(args, "--auth-type") ?? "none") as "bearer" | "apiKey" | "none",
+    authType: (getFlagValue(args, "--auth-type") ?? "none") as "bearer" | "apiKey" | "basic" | "none",
     authEnvVar: getFlagValue(args, "--auth-env") ?? "",
   });
 

--- a/src/templates/registry.ts
+++ b/src/templates/registry.ts
@@ -11,7 +11,7 @@ export interface Template {
   categories: string[];
   specUrl: string;
   baseUrl: string;
-  authType: "bearer" | "apiKey" | "none";
+  authType: "bearer" | "apiKey" | "basic" | "none";
   authHeader?: string;
   authEnvVar: string;
   docs?: string;


### PR DESCRIPTION
## Summary

- Adds \`--basic user:password\` CLI flag for OpenAPI specs using HTTP Basic security scheme
- Wires Basic auth through resolveAuth → http executor → dry-run → agent-help
- Extends Template registry to accept \`authType: \"basic\"\`
- Template \`use <name>\` handler dispatches --basic when authType is basic

## Motivation

DataForSEO (and other SEO/data APIs) use HTTP Basic auth. spec2cli internally already had the header generator for Basic, but lacked the CLI flag + Template plumbing. Without this, you can't consume a Basic-auth API via \`spec2cli use\`.

## Test plan

- [x] \`npm test\` passes (123/123, including 3 new tests for --basic resolution)
- [x] Manual smoke: spec from DataForSEO renders 437 endpoints, dry-run produces \`Authorization: Basic dGVzdDp0ZXN0\` correctly
- [x] \`tsc\` clean

## Breaking changes

None. \`--basic\` is additive. Template.authType union widened from \`bearer|apiKey|none\` to include \`basic\` — JSON files without basic remain valid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)